### PR TITLE
-headcount test

### DIFF
--- a/lib/district_repository.rb
+++ b/lib/district_repository.rb
@@ -25,10 +25,6 @@ class DistrictRepository
     insert_enrollment_info_into_districts
   end
 
-  def all
-    @districts
-  end
-
   def insert_enrollment_info_into_districts
     districts.each do |district|
       district.enrollment = @enrollment_repo.find_by_name(district.name)

--- a/lib/district_repository.rb
+++ b/lib/district_repository.rb
@@ -25,6 +25,10 @@ class DistrictRepository
     insert_enrollment_info_into_districts
   end
 
+  def all
+    @districts
+  end
+
   def insert_enrollment_info_into_districts
     districts.each do |district|
       district.enrollment = @enrollment_repo.find_by_name(district.name)

--- a/lib/enrollment.rb
+++ b/lib/enrollment.rb
@@ -25,7 +25,7 @@ class Enrollment
 
   end
 
-  def kindergarten_participation_in_year(year) @kindergarten_participation.fetch(year.to_s, nil)
-
+  def kindergarten_participation_in_year(year) 
+    @kindergarten_participation.fetch(year.to_s, nil)
   end
 end

--- a/lib/enrollment.rb
+++ b/lib/enrollment.rb
@@ -1,5 +1,6 @@
 require 'pry'
 
+
 class Enrollment
 
   attr_accessor :name, :kindergarten_participation
@@ -21,9 +22,10 @@ class Enrollment
 
   def kindergarten_participation_by_year
        @kindergarten_participation
+
   end
 
-  def kindergarten_participation_in_year(year)
-    @kindergarten_participation.fetch(year.to_s, nil)
+  def kindergarten_participation_in_year(year) @kindergarten_participation.fetch(year.to_s, nil)
+
   end
 end

--- a/lib/enrollment_repository.rb
+++ b/lib/enrollment_repository.rb
@@ -1,9 +1,12 @@
 require 'csv'
 require './lib/enrollment'
+require './lib/module_helper'
 require 'pry'
 
 
 class EnrollmentRepository
+  include Helper
+
 
   attr_reader :enrollments
 
@@ -37,7 +40,8 @@ class EnrollmentRepository
 
     data_by_location.each do |key,value|
       value.each do |line|
-        participation[line[:timeframe]] = line[:data]
+        participation[line[:timeframe]] = sanitize_data(line[:data])
+        #binding.pry if key.downcase == 'academy 20'
       end
 
       enrollments << Enrollment.new({name: key, kindergarten_participation: participation})

--- a/lib/headcount_analysis.rb
+++ b/lib/headcount_analysis.rb
@@ -1,10 +1,12 @@
 require './lib/district_repository'
 class HeadcountAnalyst
 
+  attr_reader :load_data, :dr
 
   def initialize(dr)
     @dr = dr
     @dr.load_data('./data/sample_kindergartners_file.csv')
+
   end
 
 
@@ -30,8 +32,9 @@ class HeadcountAnalyst
 
     state_name = params[:against]
     state_average = calculate_participation_average(state_name)
+    # binding.pry
 
-    district_average / state_average
+    truncate(district_average / state_average)
   end
 
   def truncate(value)
@@ -40,16 +43,19 @@ class HeadcountAnalyst
 
   def kindergarten_participation_rate_variation_trend(district_name, params)
     state_name = params[:against]
-    state = @dr.find_by_name(state_name)
+    district = @dr.find_by_name(district_name)
     district_participation_hash = district.enrollment.kindergarten_participation_by_year
+    compute_state_district_participation_trend(state_name,district_participation_hash)
+  end
 
-    district_participation_hash.each_with_index do |year,value,index|
-      #perform a lookup for year data for state
+  def compute_state_district_participation_trend(state_name,district_participation_hash)
+    state = @dr.find_by_name(state_name)
+    district_participation_hash.map do |year,value|
       state_value = state.enrollment.kindergarten_participation_in_year(year)
       [year,truncate(value/state_value)] unless state_value.nil?
     end.to_h
-
   end
+
 
 end
 

--- a/lib/module_helper.rb
+++ b/lib/module_helper.rb
@@ -1,0 +1,10 @@
+module Helper
+
+  #input = 0 .123
+  #=> 0.123
+  def sanitize_data(input)
+    input.to_s.gsub(/[\s]+/,'').to_f
+  end
+
+
+end

--- a/test/enrollment_repository_test.rb
+++ b/test/enrollment_repository_test.rb
@@ -54,7 +54,7 @@ class EnrollmentRepositoryTest < Minitest::Test
   def test_enrollment_contains_merged_data
     result = @er.enrollments.find { |enroll| enroll.name == "ACADEMY 20"}
 
-    e = {"2007"=>0.0,
+    e = {"2007"=>0.391,
    "2006"=>0.353,
    "2005"=>0.267,
    "2004"=>0.302,

--- a/test/headcount_analysis_test.rb
+++ b/test/headcount_analysis_test.rb
@@ -4,13 +4,13 @@ require './test/test_helper'
 class HeadcountAnalystTest < Minitest::Test
 
   def setup
-    @ha = HeadcountAnalyst.new
-
+    @dr = DistrictRepository.new
+    @dr.load_data('./data/Kindergartners in full-day program.csv')
+    @ha = HeadcountAnalyst.new(@dr)
   end
 
 
   def test_Kindergarten_participation_average
-    ha = HeadcountAnalyst.new
 
     assert_equal 0.766, @ha.kindergarten_participation_rate_variation('ACADEMY 20', :against => 'COLORADO')
   end
@@ -19,6 +19,11 @@ class HeadcountAnalystTest < Minitest::Test
     year_over_year = {2009 => 0.652, 2010 => 0.681, 2011 => 0.728 }
 
     assert_equal year_over_year, @ha.kindergarten_participation_rate_variation_trend('ACADEMY 20', :against => 'COLORADO')
+  end
+
+  def test_Kindergarten_participation_comparison_district_vs_district_over_time_period
+    district_vs_district = {"2007"=>0.992, "2006"=>1.05, "2005"=>0.96, "2004"=>1.258, "2008"=>0.717, "2009"=>0.652, "2010"=>0.681, "2011"=>0.727, "2012"=>0.687, "2013"=>0.693, "2014"=>0.661}
+      assert_equal district_vs_district, @ha.kindergarten_participation_rate_variation_trend('ACADEMY 20', :against => 'ADAMS-ARAPAHOE')
   end
 
 


### PR DESCRIPTION
-added Helper module with sanitize_data method
- we need to get clarification from the instructors about how to handle data. Currently truncate will not work compared to the markdown that they have provided 

see test example 

  def test_Kindergarten_participation_comparison_year_over_year
    year_over_year = {2009 => 0.652, 2010 => 0.681, 2011 => 0.728 }

```
assert_equal year_over_year, @ha.kindergarten_participation_rate_variation_trend('ACADEMY 20', :against => 'COLORADO')
```

  end

markdowns year_over_year  date 2011=> 0.728 is a round up figure 
our correct year_over_year date  2011 => 0.727 is a truncated figure
